### PR TITLE
Make `param` remove `Query` once all parameters have been consumed

### DIFF
--- a/src/Routing/Match.purs
+++ b/src/Routing/Match.purs
@@ -118,8 +118,12 @@ param key = Match \route ->
       case M.lookup key map of
         Nothing ->
           invalid $ free $ KeyNotFound key
-        Just el ->
-          pure $ Tuple (Cons (Query <<< M.delete key $ map) rs) el
+        Just el -> do
+          let remainingParams = M.delete key map
+          pure $
+            if M.isEmpty remainingParams
+              then Tuple rs el
+              else Tuple (Cons (Query remainingParams) rs) el
     _ ->
       invalid $ free ExpectedQuery
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -35,7 +35,7 @@ instance showMyRoutes :: Show MyRoutes where show = genericShow
 routing :: Match MyRoutes
 routing = oneOf
   [ Foo <$> (lit "foo" *> num) <*> params
-  , Bar <$> (lit "bar" *> bool) <*> (param "baz")
+  , Bar <$> (lit "bar" *> bool) <*> (param "baz") <* end
   , Baz <$> (lit "list" *> list num)
   , Quux <$> (lit "" *> lit "quux" *> int)
   , Corge <$> (lit "corge" *> str)
@@ -56,6 +56,10 @@ main = do
   assertEqual
     { actual: match routing "bar/true?baz=test"
     , expected: Right (Bar true "test")
+    }
+  assertEqual
+    { actual: lmap (const unit) (match routing "bar/true?baz=test&oof=true")
+    , expected: Left unit
     }
   assertEqual
     { actual: match routing "bar/false?baz=%D0%B2%D1%80%D0%B5%D0%BC%D0%B5%D0%BD%D0%BD%D1%8B%D0%B9%20%D1%84%D0%B0%D0%B9%D0%BB"


### PR DESCRIPTION
Resolves #69