### PR TITLE
Replace Data.Validation.Semiring.unV by Data.Validation.Semiring.validation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "purescript-console": "master",
     "purescript-assert": "master",
-    "purescript-record": "master",
-    "purescript-generics-rep": "master"
+    "purescript-record": "master"
   }
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -7,7 +7,6 @@
   , "effect"
   , "either"
   , "foldable-traversable"
-  , "generics-rep"
   , "integers"
   , "js-uri"
   , "lists"

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -7,10 +7,10 @@ import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
 import Data.Foldable (oneOf)
 import Data.Generic.Rep (class Generic)
-import Data.Generic.Rep.Show (genericShow)
 import Data.List (List)
 import Data.List as L
 import Data.Map as M
+import Data.Show.Generic (genericShow)
 import Data.String.NonEmpty (NonEmptyString)
 import Data.String.NonEmpty as NES
 import Data.Tuple (Tuple(..))


### PR DESCRIPTION
Data.Validation.Semiring.unV was deprecated in https://github.com/purescript/purescript-validation/pull/33.