### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#85 by @thomashoneyman)
 - Update readme to show how to use newtypes (#57 by @brodeuralexis and @JordanMartinez)
 
 ## [v10.0.1](https://github.com/purescript-contrib/purescript-routing/releases/tag/v10.0.1) - 2021-05-06

--- a/src/Routing.purs
+++ b/src/Routing.purs
@@ -8,7 +8,7 @@ import Prelude
 import Data.Either (Either)
 import Data.Maybe (fromJust)
 import JSURI (decodeURIComponent)
-import Partial.Unsafe(unsafePartial)
+import Partial.Unsafe (unsafePartial)
 import Routing.Match (Match, runMatch)
 import Routing.Parser (parse)
 

--- a/src/Routing/Match.purs
+++ b/src/Routing/Match.purs
@@ -44,6 +44,7 @@ instance matchApply :: Apply Match where
     where
     processFnErr r err =
       invalid $ err * validation identity (const one) (r2a r)
+
     processFnRes (Tuple rs a2b) =
       validation invalid (\(Tuple rss a) -> pure $ Tuple rss (a2b a)) (r2a rs)
 

--- a/src/Routing/Match/Error.purs
+++ b/src/Routing/Match/Error.purs
@@ -3,25 +3,15 @@ module Routing.Match.Error where
 import Prelude ((<>))
 
 data MatchError
-  -- expected other path part
   = UnexpectedPath String
-  -- expected "true" or "false"
   | ExpectedBoolean
-  -- expected end
   | ExpectedEnd
-  -- expected numeric literal
   | ExpectedNumber
-  -- expected integer literal
   | ExpectedInt
-  -- expected string literal (found query probably or eol)
   | ExpectedString
-  -- expected query found path part or eol
   | ExpectedQuery
-  -- expected path part found query or eol
   | ExpectedPathPart
-  -- there is no such key in query
   | KeyNotFound String
-  -- custom fail
   | Fail String
 
 showMatchError :: MatchError -> String

--- a/src/Routing/Match/Error.purs
+++ b/src/Routing/Match/Error.purs
@@ -5,23 +5,23 @@ import Prelude ((<>))
 data MatchError
   -- expected other path part
   = UnexpectedPath String
-    -- expected "true" or "false"
+  -- expected "true" or "false"
   | ExpectedBoolean
-    -- expected end
+  -- expected end
   | ExpectedEnd
-    -- expected numeric literal
+  -- expected numeric literal
   | ExpectedNumber
-    -- expected integer literal
+  -- expected integer literal
   | ExpectedInt
-    -- expected string literal (found query probably or eol)
+  -- expected string literal (found query probably or eol)
   | ExpectedString
-    -- expected query found path part or eol
+  -- expected query found path part or eol
   | ExpectedQuery
-    -- expected path part found query or eol
+  -- expected path part found query or eol
   | ExpectedPathPart
-    -- there is no such key in query
+  -- there is no such key in query
   | KeyNotFound String
-    -- custom fail
+  -- custom fail
   | Fail String
 
 showMatchError :: MatchError -> String

--- a/src/Routing/Parser.purs
+++ b/src/Routing/Parser.purs
@@ -19,11 +19,11 @@ parseQueryPart :: (String -> String) -> String -> Maybe (M.Map String String)
 parseQueryPart decoder =
   map M.fromFoldable <<< traverse part2tuple <<< S.split (S.Pattern "&")
   where
-    part2tuple :: String -> Maybe (Tuple String String)
-    part2tuple input = do
-      let keyVal = decoder <$> S.split (S.Pattern "=") input
-      guard $ A.length keyVal <= 2
-      Tuple <$> A.head keyVal <*> keyVal A.!! 1
+  part2tuple :: String -> Maybe (Tuple String String)
+  part2tuple input = do
+    let keyVal = decoder <$> S.split (S.Pattern "=") input
+    guard $ A.length keyVal <= 2
+    Tuple <$> A.head keyVal <*> keyVal A.!! 1
 
 -- | Parse hash string to `Route` with `decoder` function
 -- | applied to every hash part (usually `decodeURIComponent`)
@@ -36,10 +36,10 @@ parse decoder hash =
     Nothing ->
       pathParts hash
   where
-    pathParts str =
-      let
-        parts = L.fromFoldable $ map (Path <<< decoder) (S.split (S.Pattern "/") str)
-      in
-        case L.unsnoc parts of
-          Just { init, last: Path "" } -> init
-          _ -> parts
+  pathParts str =
+    let
+      parts = L.fromFoldable $ map (Path <<< decoder) (S.split (S.Pattern "/") str)
+    in
+      case L.unsnoc parts of
+        Just { init, last: Path "" } -> init
+        _ -> parts

--- a/src/Routing/Parser.purs
+++ b/src/Routing/Parser.purs
@@ -36,10 +36,8 @@ parse decoder hash =
     Nothing ->
       pathParts hash
   where
-  pathParts str =
-    let
-      parts = L.fromFoldable $ map (Path <<< decoder) (S.split (S.Pattern "/") str)
-    in
-      case L.unsnoc parts of
-        Just { init, last: Path "" } -> init
-        _ -> parts
+  pathParts str = do
+    let parts = L.fromFoldable $ map (Path <<< decoder) (S.split (S.Pattern "/") str)
+    case L.unsnoc parts of
+      Just { init, last: Path "" } -> init
+      _ -> parts

--- a/src/Routing/PushState.purs
+++ b/src/Routing/PushState.purs
@@ -91,6 +91,7 @@ makeInterface = do
   -- interface to behave as similarly as possible, so we use `makeImmediate`
   -- which will execute `notify` maximum once per event loop.
   schedule <- makeImmediate $ notify =<< locationState
+
   let
     stateFn op state path = do
       DOM.window

--- a/src/Routing/PushState.purs
+++ b/src/Routing/PushState.purs
@@ -102,7 +102,7 @@ makeInterface = do
 
   DOM.window
     >>= Window.toEventTarget
-    >>> DOM.addEventListener ET.popstate listener false
+      >>> DOM.addEventListener ET.popstate listener false
 
   pure
     { pushState: stateFn History.pushState
@@ -188,17 +188,17 @@ matchesWith parser cb = foldPaths go (go Nothing)
 -- | from: https://github.com/natefaubion/purescript-spork/blob/3b56c4d36e84866ed9b1bc27afa7ab4762ffdd01/src/Spork/Scheduler.purs#L20
 makeImmediate :: Effect Unit -> Effect (Effect Unit)
 makeImmediate run = do
-  document ←
+  document <-
     DOM.window
       >>= Window.document
-      >>> map HTMLDocument.toDocument
-  nextTick ← Ref.new (Right 0)
-  obsvNode ← Text.toNode <$> DOM.createTextNode "" document
-  observer ← DOM.mutationObserver \_ _ → do
+        >>> map HTMLDocument.toDocument
+  nextTick <- Ref.new (Right 0)
+  obsvNode <- Text.toNode <$> DOM.createTextNode "" document
+  observer <- DOM.mutationObserver \_ _ -> do
     Ref.modify_ (either (Right <<< add 1) Right) nextTick
     run
   DOM.observe obsvNode { characterData: true } observer
   pure do
-    Ref.read nextTick >>= traverse_ \tick → do
+    Ref.read nextTick >>= traverse_ \tick -> do
       Ref.write (Left (tick + 1)) nextTick
       DOM.setNodeValue (show tick) obsvNode

--- a/test/Test/Browser.purs
+++ b/test/Test/Browser.purs
@@ -44,7 +44,7 @@ type TestInterface =
 
 withTest :: (TestInterface -> Effect Unit) -> Effect Unit
 withTest k = do
-  doc  <- window >>= Window.document
+  doc <- window >>= Window.document
   body <- HTMLDocument.body doc >>= maybe (throwException (error "Body not found")) pure
 
   let
@@ -82,30 +82,28 @@ withTest k = do
 
     assertEq :: forall a. Show a => Eq a => String -> a -> a -> Effect Unit
     assertEq testName a b = do
-      if a == b
-        then do
-          void $ flip Node.appendChild (HTMLElement.toNode body) =<< renderSuccess testName
-        else do
-          let err = show a <> " /= " <> show b
-          _ <- flip Node.appendChild (HTMLElement.toNode body) =<< renderError testName err
-          throwException (error $ testName <> ": " <> err)
+      if a == b then do
+        void $ flip Node.appendChild (HTMLElement.toNode body) =<< renderSuccess testName
+      else do
+        let err = show a <> " /= " <> show b
+        _ <- flip Node.appendChild (HTMLElement.toNode body) =<< renderError testName err
+        throwException (error $ testName <> ": " <> err)
 
     assert :: String -> Boolean -> Effect Unit
     assert testName = assertEq testName true
 
   k { assert, assertEq }
 
-
 runHashTests :: Effect Unit -> Effect Unit
 runHashTests next = withTest \{ assert } -> do
   doneRef <- Ref.new (pure unit)
   let done = join (Ref.read doneRef) *> next
   flip Ref.write doneRef =<< hashes case _, _ of
-    Nothing, ""   -> assert "Hashes: Initial value" true
-    Just "", "a"  -> assert "Hashes: ? -> a" true *> setHash "b"
+    Nothing, "" -> assert "Hashes: Initial value" true
+    Just "", "a" -> assert "Hashes: ? -> a" true *> setHash "b"
     Just "a", "b" -> assert "Hashes: a -> b" true *> setHash ""
-    Just "b", ""  -> assert "Hashes: b -> ?" true *> done
-    _, _          -> assert "Hashes: fail" false
+    Just "b", "" -> assert "Hashes: b -> ?" true *> done
+    _, _ -> assert "Hashes: fail" false
   setHash "a"
 
 runPushStateTests :: Effect Unit
@@ -157,4 +155,4 @@ main = do
   listener <- eventListener \_ -> runHashTests runPushStateTests
   window
     >>= Window.toEventTarget
-    >>> addEventListener load listener false
+      >>> addEventListener load listener false

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -30,7 +30,8 @@ data MyRoutes
 
 derive instance eqMyRoutes :: Eq MyRoutes
 derive instance genericMyRoutes :: Generic MyRoutes _
-instance showMyRoutes :: Show MyRoutes where show = genericShow
+instance showMyRoutes :: Show MyRoutes where
+  show = genericShow
 
 routing :: Match MyRoutes
 routing = oneOf
@@ -47,11 +48,11 @@ main :: Effect Unit
 main = do
   assertEqual
     { actual: match routing "foo/12/?welp='hi'&b=false"
-    , expected: Right (Foo 12.0 (M.fromFoldable [Tuple "welp" "'hi'", Tuple "b" "false"]))
+    , expected: Right (Foo 12.0 (M.fromFoldable [ Tuple "welp" "'hi'", Tuple "b" "false" ]))
     }
   assertEqual
     { actual: match routing "foo/12?welp='hi'&b=false"
-    , expected: Right (Foo 12.0 (M.fromFoldable [Tuple "welp" "'hi'", Tuple "b" "false"]))
+    , expected: Right (Foo 12.0 (M.fromFoldable [ Tuple "welp" "'hi'", Tuple "b" "false" ]))
     }
   assertEqual
     { actual: match routing "bar/true?baz=test"
@@ -91,11 +92,11 @@ main = do
     }
   assertEqual
     { actual: match routing "list/123/"
-    , expected: Right (Baz (L.fromFoldable [123.0]))
+    , expected: Right (Baz (L.fromFoldable [ 123.0 ]))
     }
   assertEqual
     { actual: match routing "list/123/456"
-    , expected: Right (Baz (L.fromFoldable [123.0, 456.0]))
+    , expected: Right (Baz (L.fromFoldable [ 123.0, 456.0 ]))
     }
   assertEqual
     { actual: match routing "list/"
@@ -111,5 +112,5 @@ main = do
     }
   assertEqual
     { actual: match routing "foo/0/?test=a/b/c"
-    , expected: Right (Foo 0.0 (M.fromFoldable [Tuple "test" "a/b/c"]))
+    , expected: Right (Foo 0.0 (M.fromFoldable [ Tuple "test" "a/b/c" ]))
     }


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
